### PR TITLE
fix: add sent vs received message styling for multi-user chat

### DIFF
--- a/components/ChatBox.module.css
+++ b/components/ChatBox.module.css
@@ -62,3 +62,13 @@
   flex-grow: 0;
   border-bottom-left-radius: 0;
 }
+
+.sentMessage {
+  background-color: #363795;
+  color: white;
+  padding: 1em;
+  border-radius: 10px;
+  flex-grow: 0;
+  border-bottom-right-radius: 0;
+  align-self: flex-end;
+}

--- a/components/ChatBox.tsx
+++ b/components/ChatBox.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import React, { useEffect, useState, useRef } from 'react';
-import { useMessages } from '@ably/chat/react';
+import { useChatClient, useMessages } from '@ably/chat/react';
 import { Message } from '@ably/chat';
 import styles from './ChatBox.module.css';
 // Define a simplified Message interface based on how it's used in the component
 
 export default function ChatBox() {
+  const chatClient = useChatClient();
+  const currentClientId = chatClient.clientId;
   const inputBox = useRef<HTMLTextAreaElement>(null);
   const messageEndRef = useRef<HTMLDivElement>(null);
 
@@ -60,8 +62,9 @@ export default function ChatBox() {
 
   const messageElements = messages.map((message, index) => {
     const key = message.serial ?? index;
+    const isSentByMe = message.clientId === currentClientId;
     return (
-      <span key={key} className={styles.message}>
+      <span key={key} className={isSentByMe ? styles.sentMessage : styles.message}>
         {message.text}
       </span>
     );


### PR DESCRIPTION
## Summary

- Added `useChatClient` hook to get the current user's client ID
- Messages sent by the current user now appear right-aligned in dark blue; messages from others appear left-aligned in grey
- The app already generated unique client IDs per session, but the UI never distinguished between senders

See `BUG-BRIEFING.md` for the full diagnosis.

## Test plan

- [ ] Open `http://localhost:8888` (via `netlify dev`) in two browser tabs
- [ ] Send a message from each tab
- [ ] Confirm your own messages appear right-aligned (dark blue) and the other tab's messages appear left-aligned (grey)
- [ ] Confirm message history loads correctly on page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)